### PR TITLE
make-disk-image: ensure we test with SMM on.

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -398,7 +398,11 @@ let format' = format; in let
       postVM = moveOrConvertImage + postVM;
       QEMU_OPTS =
         concatStringsSep " " (lib.optional useEFIBoot "-drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
-        ++ lib.optional touchEFIVars "-drive if=pflash,format=raw,unit=1,file=$efiVars"
+        ++ lib.optionals touchEFIVars [
+          "-drive if=pflash,format=raw,unit=1,file=$efiVars"
+          # Ensure we require efi firmware to go through SMM to touch secureboot variables (once setup is done)
+          "-global driver=cfi.pflash01,property=secure,value=on"
+        ]
       );
       memSize = 1024;
     } ''


### PR DESCRIPTION
###### Motivation for this change

Requiring SMM support to touch EFI vars gets us closer to realworld

(once you got out of setup mode and into user mode, you should either use your PK to get out, or reset from BIOS, but you can't touch the KEK/DB anymore)